### PR TITLE
added logoptions attributes

### DIFF
--- a/cloudwatch_logs/lambda/cloudwatch_streamer/main.py
+++ b/cloudwatch_logs/lambda/cloudwatch_streamer/main.py
@@ -514,6 +514,12 @@ def build_params(message):
         'server-environmentId': ENVIRONMENT_ID,
         'parser': options.get('parser', 'cloudWatchLogs')
     }
+
+    # add server attributes
+    if 'attributes' in options:
+        for key in options['attributes']:
+            params['server-'+key] = options['attributes'][key]
+
     LOGGER.debug(f"Built url params: {json.dumps(params)}")
     params['token'] = WRITE_LOGS_KEY
     return params

--- a/cloudwatch_logs/tests/log_processing_test.py
+++ b/cloudwatch_logs/tests/log_processing_test.py
@@ -368,6 +368,12 @@ class TestStreamer(ScalyrTestCase):
 
         self.assertEquals(streamer.build_post_data(self.message), "12345 abc\n22222 cba\n")
 
+    def test_build_params_with_server_attributes(self):
+        streamer.LOG_GROUP_OPTIONS = {"logGroup": {"attributes": {"tier": "dev"}}}
+        self.message["owner"] = "123456789"
+        self.message["logStream"] = "cw/logstream"
+
+        self.assertEquals(streamer.build_params(self.message)["server-tier"], "dev")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added logoptions attributes - similar to attributes in scalyr agent configs
e.g
`
{
  "log/dev/.*": {
    "attributes": {
      "tier": "dev",
      "department": "mydept"
    },
    "sampling_rules": [
...
`